### PR TITLE
Fix scope for requesting a token

### DIFF
--- a/internal/sql/connection.go
+++ b/internal/sql/connection.go
@@ -111,7 +111,7 @@ func (cache ConnectionCache) sqlServerExists(ctx context.Context, connection Con
 		return ConnectionResourceStatusUnknown
 	}
 
-	policy := policy.TokenRequestOptions{Scopes: []string{"https://management.azure.com/"}}
+	policy := policy.TokenRequestOptions{Scopes: []string{"https://management.azure.com/.default"}}
 	token, err := cred.GetToken(ctx, policy)
 	if err != nil {
 		logging.AddError(ctx,


### PR DESCRIPTION
# Overview

This is a fix for a crash, which occures when using environment variables for authenticating against Azure.

In our scenario there is a pipeline and a service principal. We tried to set environment variables `AZURE_TENANT_ID`, `AZURE_CLIENT_ID` and `AZURE_CLIENT_SECRET` explicitly (thus forcing the `EnvironmentCredential` authentication of the principal).

These are the logs that we can see:

<details>
<summary>Terraform logs</summary>

```log
Planning failed. Terraform encountered an error while generating this plan.

╷
│ Error: Plugin did not respond
│ 
│ The plugin encountered an error, and failed to respond to the
│ plugin6.(*GRPCProvider).ReadDataSource call. The plugin logs may contain
│ more details.
╵
╷
│ Error: Plugin did not respond
│ 
│ The plugin encountered an error, and failed to respond to the
│ plugin6.(*GRPCProvider).ReadDataSource call. The plugin logs may contain
│ more details.
╵
╷
│ Error: Plugin did not respond
│ 
│ The plugin encountered an error, and failed to respond to the
│ plugin6.(*GRPCProvider).ReadDataSource call. The plugin logs may contain
│ more details.
╵

<truncated>

Stack trace from the terraform-provider-azuresql_v0.4.1 plugin:

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x5f7e14]

goroutine 102 [running]:
database/sql.(*DB).conn(0x0, {0xf30d28, 0xc0003c1c50}, 0x1)
	database/sql/sql.go:1282 +0x54
database/sql.(*DB).query(0xc0003c1c50?, {0xf30d28, 0xc0003c1c50}, {0xe1c6f1, 0x100}, {0xc00047d0a0, 0x1, 0x1}, 0x0?)
	database/sql/sql.go:1721 +0x57
database/sql.(*DB).QueryContext.func1(0xa0?)
	database/sql/sql.go:1704 +0x4f
database/sql.(*DB).retry(0x20?, 0xc00047cfb0)
	database/sql/sql.go:1538 +0x42
database/sql.(*DB).QueryContext(0xd20960?, {0xf30d28?, 0xc0003c1c50?}, {0xe1c6f1?, 0xc00003d29b?}, {0xc00047d0a0?, 0xc00003d2b4?, 0x5?})
	database/sql/sql.go:1703 +0xc5
database/sql.(*DB).QueryRowContext(...)
	database/sql/sql.go:1804
terraform-provider-azuresql/internal/sql.GetRoleFromName({0xf30d28, 0xc0003c1c50}, {0x0, {0xc00003d290, 0x29}, {0xc0004236c0, 0x67}, {0xc00003d290, 0x9}, {0xc00003d29b, ...}, ...}, ...)
	terraform-provider-azuresql/internal/sql/role.go:111 +0x185
terraform-provider-azuresql/internal/services/role.(*providerConfig).Read(0xc00032a008, {0xf30d28?, 0xc0003c1140?}, {{{{0xf35718, 0xc0003c1980}, {0xca5ea0, 0xc0003c18f0}}, {0xf37660, 0xc0002edf40}}, {{{0x0, ...}, ...}, ...}}, ...)
	terraform-provider-azuresql/internal/services/role/role_datasource.go:90 +0x27d
github.com/hashicorp/terraform-plugin-framework/internal/fwserver.(*Server).ReadDataSource(0xc000179ba0, {0xf30d28, 0xc0003c1140}, 0xc0003c11d0, 0xc00047d6d8)
	github.com/hashicorp/terraform-plugin-framework@v1.6.1/internal/fwserver/server_readdatasource.go:79 +0x433
github.com/hashicorp/terraform-plugin-framework/internal/proto6server.(*Server).ReadDataSource(0xc000179ba0, {0xf30d28?, 0xc0003c1020?}, 0xc0004a4100)
	github.com/hashicorp/terraform-plugin-framework@v1.6.1/internal/proto6server/server_readdatasource.go:55 +0x41c
github.com/hashicorp/terraform-plugin-go/tfprotov6/tf6server.(*server).ReadDataSource(0xc0001586e0, {0xf30d28?, 0xc0003c08a0?}, 0xc00048caf0)
	github.com/hashicorp/terraform-plugin-go@v0.22.0/tfprotov6/tf6server/server.go:686 +0x416
github.com/hashicorp/terraform-plugin-go/tfprotov6/internal/tfplugin6._Provider_ReadDataSource_Handler({0xdaa020?, 0xc0001586e0}, {0xf30d28, 0xc0003c08a0}, 0xc000412000, 0x0)
	github.com/hashicorp/terraform-plugin-go@v0.22.0/tfprotov6/internal/tfplugin6/tfplugin6_grpc.pb.go:572 +0x169
google.golang.org/grpc.(*Server).processUnaryRPC(0xc00011f000, {0xf30d28, 0xc0003c0810}, {0xf362a8, 0xc000284820}, 0xc0002e85a0, 0xc0002775f0, 0x159c360, 0x0)
	google.golang.org/grpc@v1.61.1/server.go:1385 +0xe03
google.golang.org/grpc.(*Server).handleStream(0xc00011f000, {0xf362a8, 0xc000284820}, 0xc0002e85a0)
	google.golang.org/grpc@v1.61.1/server.go:1796 +0xfec
google.golang.org/grpc.(*Server).serveStreams.func2.1()
	google.golang.org/grpc@v1.61.1/server.go:1029 +0x8b
created by google.golang.org/grpc.(*Server).serveStreams.func2 in goroutine 12
	google.golang.org/grpc@v1.61.1/server.go:1040 +0x135

Error: The terraform-provider-azuresql_v0.4.1 plugin crashed!

This is always indicative of a bug within the plugin. It would be immensely
helpful if you could report the crash with the plugin's maintainers so that it
can be fixed. The output above should help diagnose the issue.
```
</details>

<details>
<summary>TF_LOG_PROVIDER=DEBUG</summary>

```log

2024-05-24T11:46:29.247Z [ERROR] provider.terraform-provider-azuresql_v0.4.1: Response contains error diagnostic: tf_req_id=9417d075-e405-0f7e-4cbc-8377399bc173 @caller=github.com/hashicorp/terraform-plugin-go@v0.22.0/tfprotov6/internal/diag/diagnostics.go:58 diagnostic_severity=ERROR tf_data_source_type=azuresql_role
  diagnostic_detail=
  | DefaultAzureCredential authentication failed
  | POST https://login.microsoftonline.com/<tenant-id>/oauth2/v2.0/token
  | --------------------------------------------------------------------------------
  | RESPONSE 400 Bad Request
  | --------------------------------------------------------------------------------
  | {
  |   "error": "invalid_scope",
  |   "error_description": "AADSTS70011: The provided request must include a 'scope' input parameter. The provided value for the input parameter 'scope' is not valid. The scope https://management.azure.com/ openid offline_access profile is not valid. Trace ID: 3ff5b964-536a-47ef-b534-a66d9e881800 Correlation ID: b800b22e-1fc1-4a01-8465-dd0080b83e50 Timestamp: 2024-05-24 11:46:29Z",
  |   "error_codes": [
  |     70011
  |   ],
  |   "timestamp": "2024-05-24 11:46:29Z",
  |   "trace_id": "3ff5b964-536a-47ef-b534-a66d9e881800",
  |   "correlation_id": "b800b22e-1fc1-4a01-8465-dd0080b83e50"
  | }
  | --------------------------------------------------------------------------------
   diagnostic_summary="Failed to request a token for subscriptions/<subscription-id>/providers/Microsoft.Sql" tf_proto_version=6.4 tf_provider_addr=hashicorp.com/dev/azuresql @module=sdk.proto tf_rpc=ReadDataSource timestamp=2024-05-24T11:46:29.247Z

```
</details>

I tried calling the same endpoint from Postman, and with this request I got exactly the same error:

<details>
<summary>Postman - same scope</summary>

```
POST /<tenant-id>/oauth2/v2.0/token HTTP/1.1
Host: login.microsoftonline.com
Content-Type: application/x-www-form-urlencoded

grant_type:client_credentials
client_id:<client-id>
client_secret:<client-secret>
scope:https://management.azure.com/ openid offline_access profile
```

```
{
    "error": "invalid_scope",
    "error_description": "AADSTS70011: The provided request must include a 'scope' input parameter. The provided value for the input parameter 'scope' is not valid. The scope https://management.azure.com/ openid offline_access profile is not valid. Trace ID: bd1ac928-8295-42d9-877b-9ccfd4141000 Correlation ID: cd64517e-02d0-45da-8b32-46b96079e4ed Timestamp: 2024-05-24 12:14:10Z",
    "error_codes": [
        70011
    ],
    "timestamp": "2024-05-24 12:14:10Z",
    "trace_id": "bd1ac928-8295-42d9-877b-9ccfd4141000",
    "correlation_id": "cd64517e-02d0-45da-8b32-46b96079e4ed"
}
```
</details>

But when I changed the scope to `https://management.azure.com/.default`, the response is correct now:

<details>
<summary>Postman - with fixed scope</summary>

```
POST /<tenant-id>/oauth2/v2.0/token HTTP/1.1
Host: login.microsoftonline.com
Content-Type: application/x-www-form-urlencoded

grant_type:client_credentials
client_id:<client-id>
client_secret:<client-secret>
scope:https://management.azure.com/.default openid offline_access profile
```
```
{
    "token_type": "Bearer",
    "expires_in": 3599,
    "ext_expires_in": 3599,
    "access_token": "eyJ...NnQ"
}
```
</details>

Originally we did not set the environment variables, and this was leading to the library utilizing the `AzureCLICredential` (as azure cli is also available on the agents, and we can utilize it with an Azure DevOps pipelines task `AzureCLI@2`). The crash started to happen exactly when we provided the environment variables.

@jonascrevecoeur Thanks for the original library! Please let me know, what do you think about the fix?