### PR TITLE
Fix: login error from caching bad connections

### DIFF
--- a/docs/guides/changelog.md
+++ b/docs/guides/changelog.md
@@ -13,7 +13,7 @@ description: |-
 * `azuresql_permission` can now grant permissions on `azuresql_function` resources.
 
 **Bugfixes:**
-
+* Fix: Login error caused by caching faulty connections
 
 ## 0.4.1
 


### PR DESCRIPTION
The provider caches both successful and unsuccessful database connections. However, the error was not always cached along with the database connection. In some cases, this led Terraform to mistakenly believe that the retrieved connection was successful when, in reality, it was faulty.

This PR adds the error to the cache for these faulty connections.

Related issues: #45 