### PR TITLE
fix: register applications via object id

### DIFF
--- a/docs/guides/changelog.md
+++ b/docs/guides/changelog.md
@@ -7,6 +7,16 @@ description: |-
 
 # Changelog
 
+## 5.1.0
+
+**Bugfixes:**
+
+* In `azuresql_user`, renamed the experimental `object_id` parameter to `entraid_identifier` to reflect that application users must be created using their client ID (Entra ID identifier) instead of their Object ID.
+
+**Documentation:**
+
+* Add page on CICD authentication.
+
 ## 5.0.1
 
 **Features:**

--- a/docs/guides/cicd authentication.md
+++ b/docs/guides/cicd authentication.md
@@ -1,0 +1,50 @@
+# Configuring Authentication in CI/CD
+
+The `azuresql` provider uses the [Azure Default Credential Chain](https://learn.microsoft.com/en-us/dotnet/api/azure.identity.defaultazurecredential) to obtain an access token for the server or database.
+
+In non-interactive environments such as CI/CD pipelines, it is typically necessary to manually provide credentials via environment variables.
+
+## Authentication Using Client ID and Client Secret
+
+To authenticate using a service principal (client ID and client secret), set the following environment variables:
+
+- `AZURE_CLIENT_ID`
+- `AZURE_TENANT_ID`
+- `AZURE_CLIENT_SECRET`
+
+## Authentication Using Workload Identity Federation
+
+To authenticate using workload identity federation (OIDC), set the following environment variables:
+
+- `AZURE_CLIENT_ID`
+- `AZURE_TENANT_ID`
+- `ID_TOKEN`
+- `AZURE_FEDERATED_TOKEN_FILE`
+
+---
+
+# Using a Service Connection in Azure DevOps
+
+In Azure DevOps, you can retrieve the necessary credentials from a Service Connection and make them available to your Terraform tasks.
+
+To set the required environment variables, add the following task to your pipeline **before** running any Terraform commands:
+
+```yaml
+- task: AzureCLI@2
+  name: set_variables
+  displayName: "Set Terraform Credentials"
+  inputs:
+    azureSubscription: "${{ parameters.service_connection_ARM }}"
+    addSpnToEnvironment: true
+    scriptLocation: inlineScript
+    scriptType: "bash"
+    inlineScript: |
+      echo $idToken > /.idtoken
+      echo "##vso[task.setvariable variable=AZURE_CLIENT_ID]$servicePrincipalId"
+      echo "##vso[task.setvariable variable=AZURE_TENANT_ID]$tenantId"
+      echo "##vso[task.setvariable variable=AZURE_CLIENT_SECRET]$servicePrincipalKey"
+      echo "##vso[task.setvariable variable=ID_TOKEN]$idToken"
+      echo "##vso[task.setvariable variable=AZURE_FEDERATED_TOKEN_FILE]/.idtoken"
+```
+
+This task will set the necessary credentials independent of whether the connection was created via a client-secret or federated credential.

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -63,7 +63,7 @@ The following arguments are supported:
 
 - `login` (Optional, String) The ID of the `azuresql_login` resource specifying the login credentials. Available only when `authentication=SQLLogin`. 
 
-- `object_id` (Optional, String, **Preview**) Provision a user by providing their EntraID object ID. This option is only available for SQL server with `authentication="AzureAD"`.
+- `entraid_identifier` (Optional, String, **Preview**) Provision a user by providing their EntraID identifier. For Entra ID users and groups, use thier object ID; for service principals, use their application (client) ID.  This option is only available for SQL server with `authentication="AzureAD"`.
 
 ### Attributes Reference
 In addition to the arguments listed above, the following read only attributes are exported:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module terraform-provider-azuresql
 
-go 1.22.0
+go 1.23.0
+
 toolchain go1.24.1
 
 require (

--- a/internal/services/user/main.go
+++ b/internal/services/user/main.go
@@ -16,14 +16,14 @@ type UserDataSourceModel struct {
 }
 
 type UserResourceModel struct {
-	Id             types.String `tfsdk:"id"`
-	Database       types.String `tfsdk:"database"`
-	Server         types.String `tfsdk:"server"`
-	Name           types.String `tfsdk:"name"`
-	PrincipalId    types.Int64  `tfsdk:"principal_id"`
-	Authentication types.String `tfsdk:"authentication"`
-	Type           types.String `tfsdk:"type"`
-	Login          types.String `tfsdk:"login"`
-	ObjectID       types.String `tfsdk:"object_id"`
-	Sid            types.String `tfsdk:"sid"`
+	Id                types.String `tfsdk:"id"`
+	Database          types.String `tfsdk:"database"`
+	Server            types.String `tfsdk:"server"`
+	Name              types.String `tfsdk:"name"`
+	PrincipalId       types.Int64  `tfsdk:"principal_id"`
+	Authentication    types.String `tfsdk:"authentication"`
+	Type              types.String `tfsdk:"type"`
+	Login             types.String `tfsdk:"login"`
+	EntraIDIdentifier types.String `tfsdk:"entraid_identifier"`
+	Sid               types.String `tfsdk:"sid"`
 }

--- a/internal/services/user/user_resource.go
+++ b/internal/services/user/user_resource.go
@@ -97,7 +97,7 @@ func (r *UserResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
-			"object_id": schema.StringAttribute{
+			"entraid_identifier": schema.StringAttribute{
 				Optional: true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
@@ -159,24 +159,24 @@ func (r *UserResource) Create(ctx context.Context, req resource.CreateRequest, r
 	authentication := plan.Authentication.ValueString()
 	login := plan.Login.ValueString()
 
-	objectId := plan.ObjectID.ValueString()
+	entraid_identifier := plan.EntraIDIdentifier.ValueString()
 
 	if authentication != "AzureAD" && connection.Provider == "fabric" {
 		logging.AddError(ctx, "Invalid config", fmt.Sprintf("Fabric doesn't support `Authentication=%s`. The only suppored value is `Authentication='AzureAD'`.", authentication))
 		return
 	}
 
-	if authentication != "AzureAD" && objectId != "" {
-		logging.AddError(ctx, "Invalid config", "ObjectId can only be set when Authentication=AzureAD")
+	if authentication != "AzureAD" && entraid_identifier != "" {
+		logging.AddError(ctx, "Invalid config", "EntraIDIdentifier can only be set when Authentication=AzureAD")
 		return
 	}
 
-	if connection.Provider != "sqlserver" && objectId != "" {
-		logging.AddError(ctx, "Invalid config", "ObjectId is only supported in SQLServer")
+	if connection.Provider != "sqlserver" && entraid_identifier != "" {
+		logging.AddError(ctx, "Invalid config", "EntraIDIdentifier is only supported in SQLServer")
 		return
 	}
 
-	user := sql.CreateUser(ctx, connection, name, authentication, login, objectId)
+	user := sql.CreateUser(ctx, connection, name, authentication, login, entraid_identifier)
 
 	if logging.HasError(ctx) {
 		if user.Id != "" {

--- a/internal/services/user/user_resource.md
+++ b/internal/services/user/user_resource.md
@@ -63,7 +63,7 @@ The following arguments are supported:
 
 - `login` (Optional, String) The ID of the `azuresql_login` resource specifying the login credentials. Available only when `authentication=SQLLogin`. 
 
-- `object_id` (Optional, String, **Preview**) Provision a user by providing their EntraID object ID. This option is only available for SQL server with `authentication="AzureAD"`.
+- `entraid_identifier` (Optional, String, **Preview**) Provision a user by providing their EntraID identifier. For Entra ID users and groups, use thier object ID; for service principals, use their application (client) ID.  This option is only available for SQL server with `authentication="AzureAD"`.
 
 ### Attributes Reference
 In addition to the arguments listed above, the following read only attributes are exported:

--- a/internal/services/user/user_resource_test.go
+++ b/internal/services/user/user_resource_test.go
@@ -157,14 +157,14 @@ func TestAccSQLDatabaseCreateADGroup(t *testing.T) {
 	})
 }
 
-func TestAccSQLDatabaseCreateUserWithObjectId(t *testing.T) {
+func TestAccSQLDatabaseCreateUserWithEntraIDIdentity(t *testing.T) {
 	acceptance.PreCheck(t)
 	data := acceptance.BuildTestData(t)
 	r := UserResource{}
 	resource.Test(t, resource.TestCase{
 		Steps: []resource.TestStep{
 			{
-				Config: r.objectid_database(
+				Config: r.entraid_identity_database(
 					data.SQLDatabase_connection,
 					"azuresql-sid",
 					"11111111-1111-1111-1111-111111111111"),
@@ -266,7 +266,7 @@ func (r UserResource) basic_database(connection string, username string, authent
 		`, template, connection, username, authentication)
 }
 
-func (r UserResource) objectid_database(connection string, username string, objectid string) string {
+func (r UserResource) entraid_identity_database(connection string, username string, entraid_identifier string) string {
 	template := r.template()
 
 	return fmt.Sprintf(
@@ -274,12 +274,12 @@ func (r UserResource) objectid_database(connection string, username string, obje
 		%[1]s
 
 		resource "azuresql_user" "test" {
-			database  	   	= "%[2]s"
-			name           	= "%[3]s"
-			object_id 		= "%[4]s"
-			authentication 	= "AzureAD"
+			database  	   		= "%[2]s"
+			name           		= "%[3]s"
+			entraid_identifier 	= "%[4]s"
+			authentication 		= "AzureAD"
 		}
-		`, template, connection, username, objectid)
+		`, template, connection, username, entraid_identifier)
 }
 
 func (r UserResource) basic_server_duplicate(connection string, username string, authentication string) string {

--- a/internal/sql/user.go
+++ b/internal/sql/user.go
@@ -82,15 +82,15 @@ func describeAuthentication(ctx context.Context, authentication_type int64) (aut
 	}
 }
 
-func CreateUser(ctx context.Context, connection Connection, name string, authentication string, loginId string, objectId string) (user User) {
+func CreateUser(ctx context.Context, connection Connection, name string, authentication string, loginId string, entraid_identifier string) (user User) {
 
 	query := fmt.Sprintf("create user [%s]", name)
 
 	if authentication == "AzureAD" {
-		if objectId == "" {
+		if entraid_identifier == "" {
 			query += " from external provider"
 		} else {
-			sid := ObjectIDToDatabaseSID(ctx, objectId)
+			sid := ObjectIDToDatabaseSID(ctx, entraid_identifier)
 			if logging.HasError(ctx) {
 				return
 			}


### PR DESCRIPTION
This PR contains two changes:

- Add documentation for using the provider in CICD
- Rename the parameter `object_id` to `entraid_identifier`

**Renaming the parameter `object_id` to `entraid_identifier`**

In the current implementation, the `object_id` is used to register EntraID identities without requiring privileged permissions on EntraID. In the background the provider translates the `object_id` into the `database SID` which is used to register the user using the `WITH SID` clause.

This implementation fails for EntraID applications as the derived `database SID` was not correct. Although Azure doesn't document the relation, I discover that the `database SID` is obtained when passing the `CLIENT ID` instead.

This PR renames the parameter `object_id` to `entraid_identifier` to clarify that the identifier is not always the object id.
