### PR TITLE
feat(sql): handle database currently not available

### DIFF
--- a/internal/sql/connection.go
+++ b/internal/sql/connection.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	memoize "github.com/kofalt/go-memoize"
 
+	mssql "github.com/microsoft/go-mssqldb"
 	_ "github.com/microsoft/go-mssqldb/azuread"
 )
 
@@ -227,6 +228,30 @@ func retrySynapsePoolWarmup(ctx context.Context, connection *sql.DB) (err error)
 	return err
 }
 
+func isDatabaseUnavailableError(err error) bool {
+	var mssqlErr mssql.Error
+	return errors.As(err, &mssqlErr) && mssqlErr.Number == 40613
+}
+
+func retryDatabaseResume(ctx context.Context, connection *sql.DB) (err error) {
+	// Azure SQL serverless databases auto-pause after a period of inactivity.
+	// The first connection after auto-pause triggers a resume but returns error 40613.
+	// Microsoft docs state resume latency is generally in the order of one minute.
+	// Backoff delays: 5, 10, 15, 20, 30, 40 seconds (~120s total).
+	var delay = []int{5, 10, 15, 20, 30, 40}
+
+	for _, wait := range delay {
+		tflog.Info(ctx, fmt.Sprintf("Database is resuming from auto-pause. Waiting %d seconds before retry.", wait))
+		time.Sleep(time.Duration(wait) * time.Second)
+
+		err = connection.PingContext(ctx)
+		if err == nil || !isDatabaseUnavailableError(err) {
+			return err
+		}
+	}
+	return err
+}
+
 // Convert a connectionId into an actual SQL connection
 // The connectionId is a required parameter of each azuresql terraform resource
 func (cache ConnectionCache) Connect(ctx context.Context, connectionId string, server bool, requiresExist bool) Connection {
@@ -274,6 +299,10 @@ func (cache ConnectionCache) Connect(ctx context.Context, connectionId string, s
 				if err != nil && error_sql_pool.MatchString(err.Error()) {
 					err = retrySynapsePoolWarmup(ctx, connection.Connection)
 				}
+
+				if err != nil && isDatabaseUnavailableError(err) {
+					err = retryDatabaseResume(ctx, connection.Connection)
+				}
 			}
 			return connection, err
 		},
@@ -305,10 +334,15 @@ func (cache ConnectionCache) Connect(ctx context.Context, connectionId string, s
 		if conn.ConnectionResourceStatus != ConnectionResourceStatusNotFound {
 			err := conn.Connection.PingContext(ctx)
 			if err != nil {
-				tflog.Info(ctx, fmt.Sprintf("Cached connection is unhealthy, recreating it: %s", err.Error()))
-				_ = conn.Connection.Close()
-				cache.Cache.Storage.Delete(connectionId)
-				return cache.Connect(ctx, connectionId, server, requiresExist)
+				if isDatabaseUnavailableError(err) {
+					err = retryDatabaseResume(ctx, conn.Connection)
+				}
+				if err != nil {
+					tflog.Info(ctx, fmt.Sprintf("Cached connection is unhealthy, recreating it: %s", err.Error()))
+					_ = conn.Connection.Close()
+					cache.Cache.Storage.Delete(connectionId)
+					return cache.Connect(ctx, connectionId, server, requiresExist)
+				}
 			}
 		}
 

--- a/internal/sql/connection_test.go
+++ b/internal/sql/connection_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/joho/godotenv"
+	mssql "github.com/microsoft/go-mssqldb"
 	_ "github.com/microsoft/go-mssqldb/azuread"
 )
 
@@ -103,4 +104,37 @@ func TestRecoverClosedConnection(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
+}
+
+func TestIsDatabaseUnavailableError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "mssql error 40613 returns true",
+			err:      mssql.Error{Number: 40613},
+			expected: true,
+		},
+		{
+			name:     "mssql error 18456 returns false",
+			err:      mssql.Error{Number: 18456},
+			expected: false,
+		},
+		{
+			name:     "non-mssql error returns false",
+			err:      fmt.Errorf("some other error"),
+			expected: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := isDatabaseUnavailableError(tc.err)
+			if actual != tc.expected {
+				t.Errorf("isDatabaseUnavailableError(%v) = %v, want %v", tc.err, actual, tc.expected)
+			}
+		})
+	}
 }


### PR DESCRIPTION
This PR implements a retry mechanism for connecting to Azure SQL Databases with auto-pause enabled similar to the retrySynapsePoolWarmup function that already exists.

This addresses issue #201 

Example configuration:
```hcl
terraform {
  required_providers {
    azuresql = {
      source = "jonascrevecoeur/azuresql"
    }
  }
}

provider "azuresql" {}

locals {
  server   = "mysqlserver"
  database = "mysqldb"
}

data "azuresql_sqlserver" "main" {
  name = local.server
}

data "azuresql_database" "main" {
  server = data.azuresql_sqlserver.main.id
  name   = local.database
}

data "azuresql_role" "owner" {
  database = data.azuresql_database.main.id
  name     = "db_owner"
}

output "role_principal_id" {
  value = data.azuresql_role.owner.principal_id
}
```
Debug output of `terraform plan`
```text
2026-04-23T16:55:43.197+0200 [INFO]  Terraform version: 1.14.4
2026-04-23T16:55:43.197+0200 [DEBUG] using github.com/hashicorp/go-tfe v1.94.0
2026-04-23T16:55:43.197+0200 [DEBUG] using github.com/hashicorp/hcl/v2 v2.24.0
2026-04-23T16:55:43.197+0200 [DEBUG] using github.com/hashicorp/terraform-svchost v0.1.1
2026-04-23T16:55:43.197+0200 [DEBUG] using github.com/zclconf/go-cty v1.16.3
2026-04-23T16:55:43.197+0200 [INFO]  Go runtime version: go1.25.6
2026-04-23T16:55:43.198+0200 [INFO]  CLI args: []string{"C:\\Program Files\\Terraform\\terraform.exe", "plan"}
2026-04-23T16:55:43.200+0200 [DEBUG] Attempting to open CLI config file: C:\Users\woergoetter\AppData\Roaming\terraform.rc
2026-04-23T16:55:43.201+0200 [INFO]  Loading CLI configuration from C:\Users\woergoetter\AppData\Roaming\terraform.rc
2026-04-23T16:55:43.201+0200 [DEBUG] Explicit provider installation configuration is set
2026-04-23T16:55:43.201+0200 [INFO]  CLI command args: []string{"plan"}
2026-04-23T16:55:43.211+0200 [DEBUG] Provider registry.terraform.io/jonascrevecoeur/azuresql is overridden by dev_overrides
2026-04-23T16:55:43.212+0200 [DEBUG] Provider hashicorp.com/dev/azuresql is overridden as an "unmanaged provider"
2026-04-23T16:55:43.212+0200 [DEBUG] Provider registry.terraform.io/jonascrevecoeur/azuresql is overridden to load from C:\Users\woergoetter\source\repos\terraform-provider-azuresql
2026-04-23T16:55:43.212+0200 [DEBUG] checking for provisioner in "."
2026-04-23T16:55:43.212+0200 [DEBUG] checking for provisioner in "C:\\Program Files\\Terraform"
2026-04-23T16:55:43.213+0200 [DEBUG] Provider registry.terraform.io/jonascrevecoeur/azuresql is overridden by dev_overrides
2026-04-23T16:55:43.213+0200 [DEBUG] Provider hashicorp.com/dev/azuresql is overridden as an "unmanaged provider"
╷
│ Warning: Provider development overrides are in effect
│ 
│ The following provider development overrides are set in the CLI configuration:
│  - jonascrevecoeur/azuresql in C:\Users\woergoetter\source\repos\terraform-provider-azuresql
│ 
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵
2026-04-23T16:55:43.214+0200 [INFO]  backend/local: starting Plan operation
2026-04-23T16:55:43.218+0200 [DEBUG] Config.VerifyDependencySelections: skipping registry.terraform.io/jonascrevecoeur/azuresql because it's overridden by a special configuration setting
2026-04-23T16:55:43.218+0200 [DEBUG] created provider logger: level=debug
2026-04-23T16:55:43.219+0200 [INFO]  provider: configuring client automatic mTLS
2026-04-23T16:55:43.228+0200 [DEBUG] provider: starting plugin: path=C:/Users/woergoetter/source/repos/terraform-provider-azuresql/terraform-provider-azuresql.exe args=["C:/Users/woergoetter/source/repos/terraform-provider-azuresql/terraform-provider-azuresql.exe"]
2026-04-23T16:55:43.233+0200 [DEBUG] provider: plugin started: path=C:/Users/woergoetter/source/repos/terraform-provider-azuresql/terraform-provider-azuresql.exe pid=26364
2026-04-23T16:55:43.233+0200 [DEBUG] provider: waiting for RPC address: plugin=C:/Users/woergoetter/source/repos/terraform-provider-azuresql/terraform-provider-azuresql.exe
2026-04-23T16:55:43.247+0200 [INFO]  provider.terraform-provider-azuresql.exe: configuring server automatic mTLS: timestamp="2026-04-23T16:55:43.246+0200"
2026-04-23T16:55:43.255+0200 [DEBUG] provider.terraform-provider-azuresql.exe: plugin address: address=127.0.0.1:10000 network=tcp timestamp="2026-04-23T16:55:43.254+0200"
2026-04-23T16:55:43.255+0200 [DEBUG] provider: using plugin: version=6
2026-04-23T16:55:43.270+0200 [DEBUG] No provider meta schema returned
2026-04-23T16:55:43.272+0200 [DEBUG] provider.stdio: received EOF, stopping recv loop: err="rpc error: code = Unavailable desc = error reading from server: EOF"
2026-04-23T16:55:43.274+0200 [INFO]  provider: plugin process exited: plugin=C:/Users/woergoetter/source/repos/terraform-provider-azuresql/terraform-provider-azuresql.exe id=26364
2026-04-23T16:55:43.274+0200 [DEBUG] provider: plugin exited
2026-04-23T16:55:43.275+0200 [DEBUG] Building and walking validate graph
2026-04-23T16:55:43.275+0200 [DEBUG] ProviderTransformer: "data.azuresql_role.owner" (*terraform.NodeValidatableResource) needs provider["registry.terraform.io/jonascrevecoeur/azuresql"]
2026-04-23T16:55:43.275+0200 [DEBUG] ProviderTransformer: "data.azuresql_sqlserver.main" (*terraform.NodeValidatableResource) needs provider["registry.terraform.io/jonascrevecoeur/azuresql"]
2026-04-23T16:55:43.275+0200 [DEBUG] ProviderTransformer: "data.azuresql_database.main" (*terraform.NodeValidatableResource) needs provider["registry.terraform.io/jonascrevecoeur/azuresql"]
2026-04-23T16:55:43.275+0200 [DEBUG] ReferenceTransformer: "data.azuresql_sqlserver.main" references: [local.server (expand)]
2026-04-23T16:55:43.275+0200 [DEBUG] ReferenceTransformer: "data.azuresql_database.main" references: [local.database (expand) data.azuresql_sqlserver.main]
2026-04-23T16:55:43.276+0200 [DEBUG] ReferenceTransformer: "data.azuresql_role.owner" references: [data.azuresql_database.main]
2026-04-23T16:55:43.276+0200 [DEBUG] ReferenceTransformer: "local.server (expand)" references: []
2026-04-23T16:55:43.276+0200 [DEBUG] ReferenceTransformer: "local.database (expand)" references: []
2026-04-23T16:55:43.276+0200 [DEBUG] ReferenceTransformer: "output.role_principal_id (expand)" references: [data.azuresql_role.owner]
2026-04-23T16:55:43.276+0200 [DEBUG] ReferenceTransformer: "provider[\"registry.terraform.io/jonascrevecoeur/azuresql\"]" references: []
2026-04-23T16:55:43.276+0200 [DEBUG] Starting graph walk: walkValidate
2026-04-23T16:55:43.277+0200 [DEBUG] created provider logger: level=debug
2026-04-23T16:55:43.277+0200 [INFO]  provider: configuring client automatic mTLS
2026-04-23T16:55:43.282+0200 [DEBUG] provider: starting plugin: path=C:/Users/woergoetter/source/repos/terraform-provider-azuresql/terraform-provider-azuresql.exe args=["C:/Users/woergoetter/source/repos/terraform-provider-azuresql/terraform-provider-azuresql.exe"]
2026-04-23T16:55:43.285+0200 [DEBUG] provider: plugin started: path=C:/Users/woergoetter/source/repos/terraform-provider-azuresql/terraform-provider-azuresql.exe pid=18064
2026-04-23T16:55:43.285+0200 [DEBUG] provider: waiting for RPC address: plugin=C:/Users/woergoetter/source/repos/terraform-provider-azuresql/terraform-provider-azuresql.exe
2026-04-23T16:55:43.295+0200 [INFO]  provider.terraform-provider-azuresql.exe: configuring server automatic mTLS: timestamp="2026-04-23T16:55:43.294+0200"
2026-04-23T16:55:43.301+0200 [DEBUG] provider.terraform-provider-azuresql.exe: plugin address: address=127.0.0.1:10000 network=tcp timestamp="2026-04-23T16:55:43.301+0200"
2026-04-23T16:55:43.301+0200 [DEBUG] provider: using plugin: version=6
2026-04-23T16:55:43.314+0200 [DEBUG] provider.stdio: received EOF, stopping recv loop: err="rpc error: code = Unavailable desc = error reading from server: EOF"
2026-04-23T16:55:43.317+0200 [INFO]  provider: plugin process exited: plugin=C:/Users/woergoetter/source/repos/terraform-provider-azuresql/terraform-provider-azuresql.exe id=18064
2026-04-23T16:55:43.317+0200 [DEBUG] provider: plugin exited
2026-04-23T16:55:43.317+0200 [INFO]  backend/local: plan calling Plan
2026-04-23T16:55:43.317+0200 [DEBUG] Building and walking plan graph for NormalMode
2026-04-23T16:55:43.318+0200 [DEBUG] ProviderTransformer: "data.azuresql_role.owner (expand)" (*terraform.nodeExpandPlannableResource) needs provider["registry.terraform.io/jonascrevecoeur/azuresql"]
2026-04-23T16:55:43.318+0200 [DEBUG] ProviderTransformer: "data.azuresql_sqlserver.main (expand)" (*terraform.nodeExpandPlannableResource) needs provider["registry.terraform.io/jonascrevecoeur/azuresql"]
2026-04-23T16:55:43.318+0200 [DEBUG] ProviderTransformer: "data.azuresql_database.main (expand)" (*terraform.nodeExpandPlannableResource) needs provider["registry.terraform.io/jonascrevecoeur/azuresql"]
2026-04-23T16:55:43.318+0200 [DEBUG] ReferenceTransformer: "data.azuresql_role.owner (expand)" references: [data.azuresql_database.main (expand)]
2026-04-23T16:55:43.318+0200 [DEBUG] ReferenceTransformer: "local.database (expand)" references: []
2026-04-23T16:55:43.318+0200 [DEBUG] ReferenceTransformer: "local.server (expand)" references: []
2026-04-23T16:55:43.318+0200 [DEBUG] ReferenceTransformer: "output.role_principal_id (expand)" references: [data.azuresql_role.owner (expand)]
2026-04-23T16:55:43.318+0200 [DEBUG] ReferenceTransformer: "provider[\"registry.terraform.io/jonascrevecoeur/azuresql\"]" references: []
2026-04-23T16:55:43.318+0200 [DEBUG] ReferenceTransformer: "data.azuresql_sqlserver.main (expand)" references: [local.server (expand)]
2026-04-23T16:55:43.318+0200 [DEBUG] ReferenceTransformer: "data.azuresql_database.main (expand)" references: [local.database (expand) data.azuresql_sqlserver.main (expand)]
2026-04-23T16:55:43.318+0200 [DEBUG] Starting graph walk: walkPlan
2026-04-23T16:55:43.319+0200 [DEBUG] created provider logger: level=debug
2026-04-23T16:55:43.319+0200 [INFO]  provider: configuring client automatic mTLS
2026-04-23T16:55:43.322+0200 [DEBUG] provider: starting plugin: path=C:/Users/woergoetter/source/repos/terraform-provider-azuresql/terraform-provider-azuresql.exe args=["C:/Users/woergoetter/source/repos/terraform-provider-azuresql/terraform-provider-azuresql.exe"]
2026-04-23T16:55:43.324+0200 [DEBUG] provider: plugin started: path=C:/Users/woergoetter/source/repos/terraform-provider-azuresql/terraform-provider-azuresql.exe pid=1488
2026-04-23T16:55:43.324+0200 [DEBUG] provider: waiting for RPC address: plugin=C:/Users/woergoetter/source/repos/terraform-provider-azuresql/terraform-provider-azuresql.exe
2026-04-23T16:55:43.334+0200 [INFO]  provider.terraform-provider-azuresql.exe: configuring server automatic mTLS: timestamp="2026-04-23T16:55:43.334+0200"
2026-04-23T16:55:43.340+0200 [DEBUG] provider.terraform-provider-azuresql.exe: plugin address: address=127.0.0.1:10000 network=tcp timestamp="2026-04-23T16:55:43.340+0200"
2026-04-23T16:55:43.340+0200 [DEBUG] provider: using plugin: version=6
2026-04-23T16:55:43.351+0200 [DEBUG] Resource instance state not found for node "data.azuresql_sqlserver.main", instance data.azuresql_sqlserver.main
2026-04-23T16:55:43.351+0200 [DEBUG] ReferenceTransformer: "data.azuresql_sqlserver.main" references: []
data.azuresql_sqlserver.main: Reading...
2026-04-23T16:55:43.353+0200 [DEBUG] provider.terraform-provider-azuresql.exe: Value switched to prior value due to semantic equality logic: @caller=C:/Users/woergoetter/go/pkg/mod/github.com/hashicorp/terraform-plugin-framework@v1.19.0/internal/fwschemadata/value_semantic_equality.go:91 @module=sdk.framework tf_provider_addr=hashicorp.com/dev/azuresql tf_rpc=ReadDataSource tf_attribute_path=name tf_data_source_type=azuresql_sqlserver tf_req_id=bf5b1e0b-c147-e80e-7fef-46bf44c5e9a6 timestamp="2026-04-23T16:55:43.353+0200"
data.azuresql_sqlserver.main: Read complete after 0s [id=sqlserver::mysqlserver:1433]
2026-04-23T16:55:43.353+0200 [DEBUG] Resource instance state not found for node "data.azuresql_database.main", instance data.azuresql_database.main
2026-04-23T16:55:43.353+0200 [DEBUG] ReferenceTransformer: "data.azuresql_database.main" references: []
data.azuresql_database.main: Reading...
2026-04-23T16:55:43.355+0200 [DEBUG] provider.terraform-provider-azuresql.exe: Value switched to prior value due to semantic equality logic: tf_provider_addr=hashicorp.com/dev/azuresql @caller=C:/Users/woergoetter/go/pkg/mod/github.com/hashicorp/terraform-plugin-framework@v1.19.0/internal/fwschemadata/value_semantic_equality.go:91 @module=sdk.framework tf_attribute_path=server tf_data_source_type=azuresql_database tf_req_id=e71b89d7-a175-f307-a1eb-8cdd1b2fe02b tf_rpc=ReadDataSource timestamp="2026-04-23T16:55:43.355+0200"
2026-04-23T16:55:43.355+0200 [DEBUG] provider.terraform-provider-azuresql.exe: Value switched to prior value due to semantic equality logic: @module=sdk.framework tf_attribute_path=name @caller=C:/Users/woergoetter/go/pkg/mod/github.com/hashicorp/terraform-plugin-framework@v1.19.0/internal/fwschemadata/value_semantic_equality.go:91 tf_data_source_type=azuresql_database tf_provider_addr=hashicorp.com/dev/azuresql tf_req_id=e71b89d7-a175-f307-a1eb-8cdd1b2fe02b tf_rpc=ReadDataSource timestamp="2026-04-23T16:55:43.355+0200"
data.azuresql_database.main: Read complete after 0s [id=sqlserver::mysqlserver:1433:mysqldb]
2026-04-23T16:55:43.356+0200 [DEBUG] Resource instance state not found for node "data.azuresql_role.owner", instance data.azuresql_role.owner
2026-04-23T16:55:43.356+0200 [DEBUG] ReferenceTransformer: "data.azuresql_role.owner" references: []
data.azuresql_role.owner: Reading...
2026-04-23T16:55:43.358+0200 [INFO]  provider.terraform-provider-azuresql.exe: Fetching connection to sqlserver::mysqlserver:1433:mysqldb: tf_data_source_type=azuresql_role tf_provider_addr=hashicorp.com/dev/azuresql tf_rpc=ReadDataSource @module=azuresql tf_req_id=bed9094f-9284-d16e-cfcb-2afc40138a53 @caller=C:/Users/woergoetter/source/repos/terraform-provider-azuresql/internal/sql/connection.go:259 timestamp="2026-04-23T16:55:43.358+0200"
2026-04-23T16:55:43.358+0200 [DEBUG] provider.terraform-provider-azuresql.exe: IsServerConnection: false: tf_data_source_type=azuresql_role tf_req_id=bed9094f-9284-d16e-cfcb-2afc40138a53 tf_rpc=ReadDataSource @module=azuresql tf_provider_addr=hashicorp.com/dev/azuresql @caller=C:/Users/woergoetter/source/repos/terraform-provider-azuresql/internal/sql/connection.go:271 timestamp="2026-04-23T16:55:43.358+0200"
2026-04-23T16:55:43.358+0200 [DEBUG] provider.terraform-provider-azuresql.exe: Check database exists: tf_data_source_type=azuresql_role tf_provider_addr=hashicorp.com/dev/azuresql tf_req_id=bed9094f-9284-d16e-cfcb-2afc40138a53 tf_rpc=ReadDataSource @caller=C:/Users/woergoetter/source/repos/terraform-provider-azuresql/internal/sql/connection.go:278 @module=azuresql timestamp="2026-04-23T16:55:43.358+0200"
2026-04-23T16:55:43.358+0200 [INFO]  provider.terraform-provider-azuresql.exe: Fetching connection to sqlserver::mysqlserver:1433: @module=azuresql tf_data_source_type=azuresql_role tf_provider_addr=hashicorp.com/dev/azuresql tf_req_id=bed9094f-9284-d16e-cfcb-2afc40138a53 tf_rpc=ReadDataSource @caller=C:/Users/woergoetter/source/repos/terraform-provider-azuresql/internal/sql/connection.go:259 timestamp="2026-04-23T16:55:43.358+0200"
2026-04-23T16:55:43.358+0200 [DEBUG] provider.terraform-provider-azuresql.exe: IsServerConnection: true: @caller=C:/Users/woergoetter/source/repos/terraform-provider-azuresql/internal/sql/connection.go:271 tf_data_source_type=azuresql_role tf_req_id=bed9094f-9284-d16e-cfcb-2afc40138a53 @module=azuresql tf_provider_addr=hashicorp.com/dev/azuresql tf_rpc=ReadDataSource timestamp="2026-04-23T16:55:43.358+0200"
2026-04-23T16:55:43.358+0200 [DEBUG] provider.terraform-provider-azuresql.exe: Connection string: sqlserver://mysqlserver.database.windows.net:1433?fedauth=ActiveDirectoryDefault: @caller=C:/Users/woergoetter/source/repos/terraform-provider-azuresql/internal/sql/connection.go:287 @module=azuresql tf_data_source_type=azuresql_role tf_provider_addr=hashicorp.com/dev/azuresql tf_rpc=ReadDataSource tf_req_id=bed9094f-9284-d16e-cfcb-2afc40138a53 timestamp="2026-04-23T16:55:43.358+0200"
2026-04-23T16:55:43.358+0200 [DEBUG] provider.terraform-provider-azuresql.exe: Pinging database: @caller=C:/Users/woergoetter/source/repos/terraform-provider-azuresql/internal/sql/connection.go:291 @module=azuresql tf_data_source_type=azuresql_role tf_req_id=bed9094f-9284-d16e-cfcb-2afc40138a53 tf_provider_addr=hashicorp.com/dev/azuresql tf_rpc=ReadDataSource timestamp="2026-04-23T16:55:43.358+0200"
2026-04-23T16:55:45.281+0200 [INFO]  provider.terraform-provider-azuresql.exe: Successfully opened a new connection.: @caller=C:/Users/woergoetter/source/repos/terraform-provider-azuresql/internal/sql/connection.go:351 tf_data_source_type=azuresql_role tf_rpc=ReadDataSource @module=azuresql tf_provider_addr=hashicorp.com/dev/azuresql tf_req_id=bed9094f-9284-d16e-cfcb-2afc40138a53 timestamp="2026-04-23T16:55:45.281+0200"
2026-04-23T16:55:45.398+0200 [DEBUG] provider.terraform-provider-azuresql.exe: Connection string: sqlserver://mysqlserver.database.windows.net:1433?database=mysqldb&fedauth=ActiveDirectoryDefault: @module=azuresql tf_provider_addr=hashicorp.com/dev/azuresql tf_rpc=ReadDataSource @caller=C:/Users/woergoetter/source/repos/terraform-provider-azuresql/internal/sql/connection.go:287 tf_data_source_type=azuresql_role tf_req_id=bed9094f-9284-d16e-cfcb-2afc40138a53 timestamp="2026-04-23T16:55:45.398+0200"
2026-04-23T16:55:45.398+0200 [DEBUG] provider.terraform-provider-azuresql.exe: Pinging database: tf_req_id=bed9094f-9284-d16e-cfcb-2afc40138a53 @module=azuresql tf_data_source_type=azuresql_role tf_rpc=ReadDataSource @caller=C:/Users/woergoetter/source/repos/terraform-provider-azuresql/internal/sql/connection.go:291 tf_provider_addr=hashicorp.com/dev/azuresql timestamp="2026-04-23T16:55:45.398+0200"
data.azuresql_role.owner: Still reading... [00m10s elapsed]
2026-04-23T16:56:01.269+0200 [INFO]  provider.terraform-provider-azuresql.exe: Pinging database failed with error: mssql: login error: Database 'mysqldb' on server 'mysqlserver.database.windows.net' is not currently available.  Please retry the connection later.  If the problem persists, contact customer support, and provide them the session tracing ID of '{124CB314-5F01-4AEF-911E-740BDC2694EF}'.: tf_data_source_type=azuresql_role tf_provider_addr=hashicorp.com/dev/azuresql tf_req_id=bed9094f-9284-d16e-cfcb-2afc40138a53 @module=azuresql tf_rpc=ReadDataSource @caller=C:/Users/woergoetter/source/repos/terraform-provider-azuresql/internal/sql/connection.go:295 timestamp="2026-04-23T16:56:01.269+0200"
2026-04-23T16:56:01.270+0200 [INFO]  provider.terraform-provider-azuresql.exe: Database is resuming from auto-pause. Waiting 5 seconds before retry.: tf_data_source_type=azuresql_role tf_provider_addr=hashicorp.com/dev/azuresql tf_rpc=ReadDataSource @module=azuresql tf_req_id=bed9094f-9284-d16e-cfcb-2afc40138a53 @caller=C:/Users/woergoetter/source/repos/terraform-provider-azuresql/internal/sql/connection.go:244 timestamp="2026-04-23T16:56:01.269+0200"
data.azuresql_role.owner: Still reading... [00m20s elapsed]
data.azuresql_role.owner: Still reading... [00m30s elapsed]
2026-04-23T16:56:22.055+0200 [INFO]  provider.terraform-provider-azuresql.exe: Database is resuming from auto-pause. Waiting 10 seconds before retry.: tf_data_source_type=azuresql_role tf_provider_addr=hashicorp.com/dev/azuresql tf_req_id=bed9094f-9284-d16e-cfcb-2afc40138a53 @caller=C:/Users/woergoetter/source/repos/terraform-provider-azuresql/internal/sql/connection.go:244 tf_rpc=ReadDataSource @module=azuresql timestamp="2026-04-23T16:56:22.054+0200"
data.azuresql_role.owner: Still reading... [00m40s elapsed]
data.azuresql_role.owner: Still reading... [00m50s elapsed]
2026-04-23T16:56:34.381+0200 [INFO]  provider.terraform-provider-azuresql.exe: Successfully opened a new connection.: @caller=C:/Users/woergoetter/source/repos/terraform-provider-azuresql/internal/sql/connection.go:351 tf_data_source_type=azuresql_role tf_req_id=bed9094f-9284-d16e-cfcb-2afc40138a53 @module=azuresql tf_provider_addr=hashicorp.com/dev/azuresql tf_rpc=ReadDataSource timestamp="2026-04-23T16:56:34.381+0200"
2026-04-23T16:56:34.638+0200 [DEBUG] provider.terraform-provider-azuresql.exe: Value switched to prior value due to semantic equality logic: @module=sdk.framework tf_attribute_path=name tf_data_source_type=azuresql_role tf_req_id=bed9094f-9284-d16e-cfcb-2afc40138a53 @caller=C:/Users/woergoetter/go/pkg/mod/github.com/hashicorp/terraform-plugin-framework@v1.19.0/internal/fwschemadata/value_semantic_equality.go:91 tf_provider_addr=hashicorp.com/dev/azuresql tf_rpc=ReadDataSource timestamp="2026-04-23T16:56:34.638+0200"
2026-04-23T16:56:34.639+0200 [DEBUG] provider.terraform-provider-azuresql.exe: Value switched to prior value due to semantic equality logic: tf_provider_addr=hashicorp.com/dev/azuresql @caller=C:/Users/woergoetter/go/pkg/mod/github.com/hashicorp/terraform-plugin-framework@v1.19.0/internal/fwschemadata/value_semantic_equality.go:91 @module=sdk.framework tf_data_source_type=azuresql_role tf_req_id=bed9094f-9284-d16e-cfcb-2afc40138a53 tf_rpc=ReadDataSource tf_attribute_path=database timestamp="2026-04-23T16:56:34.638+0200"
data.azuresql_role.owner: Read complete after 52s [id=sqlserver::mysqlserver:1433:mysqldb/role/16384]
2026-04-23T16:56:34.642+0200 [DEBUG] provider.stdio: received EOF, stopping recv loop: err="rpc error: code = Unavailable desc = error reading from server: EOF"
2026-04-23T16:56:34.646+0200 [INFO]  provider: plugin process exited: plugin=C:/Users/woergoetter/source/repos/terraform-provider-azuresql/terraform-provider-azuresql.exe id=1488
2026-04-23T16:56:34.646+0200 [DEBUG] provider: plugin exited
2026-04-23T16:56:34.647+0200 [DEBUG] building apply graph to check for errors
2026-04-23T16:56:34.647+0200 [DEBUG] ProviderTransformer: "data.azuresql_database.main (expand)" (*terraform.nodeExpandApplyableResource) needs provider["registry.terraform.io/jonascrevecoeur/azuresql"]
2026-04-23T16:56:34.647+0200 [DEBUG] ProviderTransformer: "data.azuresql_role.owner (expand)" (*terraform.nodeExpandApplyableResource) needs provider["registry.terraform.io/jonascrevecoeur/azuresql"]
2026-04-23T16:56:34.647+0200 [DEBUG] ProviderTransformer: "data.azuresql_sqlserver.main (expand)" (*terraform.nodeExpandApplyableResource) needs provider["registry.terraform.io/jonascrevecoeur/azuresql"]
2026-04-23T16:56:34.648+0200 [DEBUG] ReferenceTransformer: "output.role_principal_id (expand)" references: [data.azuresql_role.owner (expand)]
2026-04-23T16:56:34.648+0200 [DEBUG] ReferenceTransformer: "provider[\"registry.terraform.io/jonascrevecoeur/azuresql\"]" references: []
2026-04-23T16:56:34.648+0200 [DEBUG] ReferenceTransformer: "data.azuresql_sqlserver.main (expand)" references: [local.server (expand)]
2026-04-23T16:56:34.648+0200 [DEBUG] ReferenceTransformer: "data.azuresql_database.main (expand)" references: [local.database (expand) data.azuresql_sqlserver.main (expand)]
2026-04-23T16:56:34.648+0200 [DEBUG] ReferenceTransformer: "data.azuresql_role.owner (expand)" references: [data.azuresql_database.main (expand)]
2026-04-23T16:56:34.648+0200 [DEBUG] ReferenceTransformer: "local.server (expand)" references: []
2026-04-23T16:56:34.648+0200 [DEBUG] ReferenceTransformer: "local.database (expand)" references: []
2026-04-23T16:56:34.648+0200 [INFO]  backend/local: plan operation completed

Changes to Outputs:
  + role_principal_id = 16384

You can apply this plan to save these new output values to the Terraform state, without changing any real infrastructure.
```

> Parts of this code were generated with the assistance of GitHub Copilot and reviewed/tested by me.