### PR TITLE
Allow setting user type for Entra ID group creation via identifier

### DIFF
--- a/docs/guides/changelog.md
+++ b/docs/guides/changelog.md
@@ -7,6 +7,12 @@ description: |-
 
 # Changelog
 
+## 5.4.5
+
+**Features:**
+
+* The `type` attribute of `azuresql_user` can now be set to `AD group` to provision an Entra ID group via `entraid_identifier`. Previously the user type was hardcoded to `E` (AD user).
+
 ## 5.4.4
 
 **Fixes:**

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -55,6 +55,19 @@ resource "azuresql_user" "spuser" {
   authentication     = "AzureAD"
   entraid_identifier = data.azuread_service_principal.app.object_id
 }
+
+# map an Azure AD group to a SQL user, tracking its identity
+data "azuread_group" "group" {
+  display_name = "my-azure-ad-group"
+}
+
+resource "azuresql_user" "groupuser" {
+  database           = data.azuresql_database.database.id
+  name               = data.azuread_group.group.display_name
+  authentication     = "AzureAD"
+  entraid_identifier = data.azuread_group.group.object_id
+  type               = "AD group"
+}
 ```
 
 ~> When `authentication="AzureAD"` is used without `entraid_identifier`, the SQL user is created via `FROM EXTERNAL PROVIDER` and the identity is resolved by name at creation time. If the underlying Entra ID identity is later destroyed and recreated with the same name (e.g., an App Registration reprovisioned in another Terraform stack), the SQL user will retain the old object ID and become stale. To detect this drift, set `entraid_identifier` to the object ID of the Entra ID identity, preferably by referencing an `azuread_service_principal` or `azuread_user` data source. This ensures that when the identity is recreated, Terraform detects the changed object ID and replaces the SQL user.
@@ -79,14 +92,15 @@ The following arguments are supported:
 
 - `password` (Optional, String) The password of the user. Available only when `authentication=DBSQLLogin`.
 
-- `entraid_identifier` (Optional, String, **Preview**) Provision a user by providing their EntraID identifier. For Entra ID users and groups, use thier object ID; for service principals, use their application (client) ID.  This option is only available for SQL server with `authentication="AzureAD"`.
+- `entraid_identifier` (Optional, String, **Preview**) Provision a user by providing their EntraID identifier. For Entra ID users and groups, use thier object ID; for service principals, use their application (client) ID.  This option is only available for SQL server with `authentication="AzureAD"`. When provisioning a group, also set `type="AD group"`.
+
+- `type` (Optional, String) Database/Server user type. Possible values `SQL user`, `AD group`, `AD user`. Can only be set when `entraid_identifier` is specified, to choose between provisioning an `AD user` (the default) or an `AD group`.
 
 ### Attributes Reference
 In addition to the arguments listed above, the following read only attributes are exported:
 
 - `id` (String) The azuresql ID of the user resource.
 - `principal_id` (Number) Principal ID of the user in the database.
-- `type` (String) Database/Server user type. Possible values `SQL user`, `AD group`, `AD user`. 
 - `sid` (string) SID assigned to the principal in the database.
   
 ## ID structure

--- a/internal/services/user/user_resource.go
+++ b/internal/services/user/user_resource.go
@@ -41,7 +41,7 @@ func (r *UserResource) Metadata(_ context.Context, req resource.MetadataRequest,
 type replaceIfSetOrChanged struct{}
 
 func (m replaceIfSetOrChanged) Description(ctx context.Context) string {
-	return "Setting or changing entraid_identifier forces replacement."
+	return "Setting or changing this attribute forces replacement."
 }
 
 func (m replaceIfSetOrChanged) MarkdownDescription(ctx context.Context) string {
@@ -123,8 +123,17 @@ func (r *UserResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 				},
 			},
 			"type": schema.StringAttribute{
-				Computed:    true,
-				Description: "Type of the user in the database. Possible types are TODO.",
+				Optional: true,
+				Computed: true,
+				Description: "Type of the user in the database. Possible values are `SQL user`, `AD user` and `AD group`. " +
+					"Can only be set when `entraid_identifier` is specified, to choose between creating an `AD user` (the default) or an `AD group`.",
+				Validators: []validator.String{
+					stringvalidator.OneOf("AD user", "AD group"),
+				},
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+					replaceIfSetOrChanged{},
+				},
 			},
 			"login": schema.StringAttribute{
 				Optional:    true,
@@ -186,6 +195,12 @@ func (r UserResource) ValidateConfig(ctx context.Context, req resource.ValidateC
 			"password is only supported when authentication equals `DBSQLLogin`")
 		return
 	}
+
+	if !data.Type.IsNull() && data.EntraIDIdentifier.IsNull() {
+		logging.AddAttributeError(ctx, path.Root("type"), "Invalid attribute configuration",
+			"type can only be set when entraid_identifier is specified")
+		return
+	}
 }
 
 func (r *UserResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
@@ -239,7 +254,14 @@ func (r *UserResource) Create(ctx context.Context, req resource.CreateRequest, r
 		return
 	}
 
-	user := sql.CreateUser(ctx, connection, name, password, authentication, login, entraid_identifier)
+	userType := plan.Type.ValueString()
+
+	if userType != "" && entraid_identifier == "" {
+		logging.AddError(ctx, "Invalid config", "type can only be set when entraid_identifier is specified")
+		return
+	}
+
+	user := sql.CreateUser(ctx, connection, name, password, authentication, login, entraid_identifier, userType)
 
 	if logging.HasError(ctx) {
 		if user.Id != "" {

--- a/internal/services/user/user_resource.md
+++ b/internal/services/user/user_resource.md
@@ -55,6 +55,19 @@ resource "azuresql_user" "spuser" {
   authentication     = "AzureAD"
   entraid_identifier = data.azuread_service_principal.app.object_id
 }
+
+# map an Azure AD group to a SQL user, tracking its identity
+data "azuread_group" "group" {
+  display_name = "my-azure-ad-group"
+}
+
+resource "azuresql_user" "groupuser" {
+  database           = data.azuresql_database.database.id
+  name               = data.azuread_group.group.display_name
+  authentication     = "AzureAD"
+  entraid_identifier = data.azuread_group.group.object_id
+  type               = "AD group"
+}
 ```
 
 ~> When `authentication="AzureAD"` is used without `entraid_identifier`, the SQL user is created via `FROM EXTERNAL PROVIDER` and the identity is resolved by name at creation time. If the underlying Entra ID identity is later destroyed and recreated with the same name (e.g., an App Registration reprovisioned in another Terraform stack), the SQL user will retain the old object ID and become stale. To detect this drift, set `entraid_identifier` to the object ID of the Entra ID identity, preferably by referencing an `azuread_service_principal` or `azuread_user` data source. This ensures that when the identity is recreated, Terraform detects the changed object ID and replaces the SQL user.
@@ -79,14 +92,15 @@ The following arguments are supported:
 
 - `password` (Optional, String) The password of the user. Available only when `authentication=DBSQLLogin`.
 
-- `entraid_identifier` (Optional, String, **Preview**) Provision a user by providing their EntraID identifier. For Entra ID users and groups, use thier object ID; for service principals, use their application (client) ID.  This option is only available for SQL server with `authentication="AzureAD"`.
+- `entraid_identifier` (Optional, String, **Preview**) Provision a user by providing their EntraID identifier. For Entra ID users and groups, use thier object ID; for service principals, use their application (client) ID.  This option is only available for SQL server with `authentication="AzureAD"`. When provisioning a group, also set `type="AD group"`.
+
+- `type` (Optional, String) Database/Server user type. Possible values `SQL user`, `AD group`, `AD user`. Can only be set when `entraid_identifier` is specified, to choose between provisioning an `AD user` (the default) or an `AD group`.
 
 ### Attributes Reference
 In addition to the arguments listed above, the following read only attributes are exported:
 
 - `id` (String) The azuresql ID of the user resource.
 - `principal_id` (Number) Principal ID of the user in the database.
-- `type` (String) Database/Server user type. Possible values `SQL user`, `AD group`, `AD user`. 
 - `sid` (string) SID assigned to the principal in the database.
   
 ## ID structure

--- a/internal/services/user/user_resource_test.go
+++ b/internal/services/user/user_resource_test.go
@@ -174,6 +174,42 @@ func TestAccSQLDatabaseCreateUserWithEntraIDIdentity(t *testing.T) {
 	})
 }
 
+func TestAccSQLDatabaseCreateGroupWithEntraIDIdentity(t *testing.T) {
+	acceptance.PreCheck(t)
+	data := acceptance.BuildTestData(t)
+	r := UserResource{}
+	resource.Test(t, resource.TestCase{
+		Steps: []resource.TestStep{
+			{
+				Config: r.entraid_identity_database_with_type(
+					data.SQLDatabase_connection,
+					"azuresql-group-sid",
+					"22222222-2222-2222-2222-222222222222",
+					"AD group"),
+				ProtoV6ProviderFactories: acceptance.TestAccProtoV6ProviderFactories,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("azuresql_user.test", "type", "AD group"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccUserTypeRequiresEntraIDIdentifier(t *testing.T) {
+	acceptance.PreCheck(t)
+	data := acceptance.BuildTestData(t)
+	r := UserResource{}
+	resource.Test(t, resource.TestCase{
+		Steps: []resource.TestStep{
+			{
+				Config:                   r.database_with_type(data.SQLDatabase_connection, os.Getenv("AZURE_AD_GROUP"), "AD group"),
+				ProtoV6ProviderFactories: acceptance.TestAccProtoV6ProviderFactories,
+				ExpectError:              regexp.MustCompile("type can only be set when entraid_identifier is specified"),
+			},
+		},
+	})
+}
+
 func TestAccSynapseServerCreateADGroup(t *testing.T) {
 	acceptance.PreCheck(t)
 	data := acceptance.BuildTestData(t)
@@ -306,6 +342,39 @@ func (r UserResource) entraid_identity_database(connection string, username stri
 			authentication 		= "AzureAD"
 		}
 		`, template, connection, username, entraid_identifier)
+}
+
+func (r UserResource) entraid_identity_database_with_type(connection string, username string, entraid_identifier string, userType string) string {
+	template := r.template()
+
+	return fmt.Sprintf(
+		`
+		%[1]s
+
+		resource "azuresql_user" "test" {
+			database  	   		= "%[2]s"
+			name           		= "%[3]s"
+			entraid_identifier 	= "%[4]s"
+			authentication 		= "AzureAD"
+			type				= "%[5]s"
+		}
+		`, template, connection, username, entraid_identifier, userType)
+}
+
+func (r UserResource) database_with_type(connection string, username string, userType string) string {
+	template := r.template()
+
+	return fmt.Sprintf(
+		`
+		%[1]s
+
+		resource "azuresql_user" "test" {
+			database  	   	= "%[2]s"
+			name           	= "%[3]s"
+			authentication 	= "AzureAD"
+			type			= "%[4]s"
+		}
+		`, template, connection, username, userType)
 }
 
 func (r UserResource) basic_server_duplicate(connection string, username string, authentication string) string {

--- a/internal/sql/user.go
+++ b/internal/sql/user.go
@@ -69,6 +69,21 @@ func describeUserType(ctx context.Context, userType string) (userTypeLong string
 	}
 }
 
+// Inverse of describeUserType for the types which can be chosen
+// when creating a user via an entraid_identifier.
+func userTypeCode(ctx context.Context, userType string) string {
+	switch userType {
+	case "", "AD user":
+		return "E"
+	case "AD group":
+		return "X"
+	default:
+		logging.AddError(ctx, "Invalid user type",
+			fmt.Sprintf("User type %s cannot be used when creating a user via entraid_identifier. Possible values are `AD user` and `AD group`.", userType))
+		return ""
+	}
+}
+
 func describeAuthentication(ctx context.Context, authentication_type int64) (authentication string) {
 	switch authentication_type {
 	case 0:
@@ -85,7 +100,7 @@ func describeAuthentication(ctx context.Context, authentication_type int64) (aut
 	}
 }
 
-func CreateUser(ctx context.Context, connection Connection, name string, password string, authentication string, loginId string, entraid_identifier string) (user User) {
+func CreateUser(ctx context.Context, connection Connection, name string, password string, authentication string, loginId string, entraid_identifier string, userType string) (user User) {
 
 	query := fmt.Sprintf("create user [%s]", name)
 
@@ -94,10 +109,11 @@ func CreateUser(ctx context.Context, connection Connection, name string, passwor
 			query += " from external provider"
 		} else {
 			sid := ObjectIDToDatabaseSID(ctx, entraid_identifier)
+			typeCode := userTypeCode(ctx, userType)
 			if logging.HasError(ctx) {
 				return
 			}
-			query += " with sid=" + sid + ", type=E"
+			query += " with sid=" + sid + ", type=" + typeCode
 		}
 	} else if authentication == "SQLLogin" {
 		login := ParseLoginId(ctx, loginId)

--- a/internal/sql/user_test.go
+++ b/internal/sql/user_test.go
@@ -1,0 +1,19 @@
+package sql
+
+import (
+	"terraform-provider-azuresql/internal/logging"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUserTypeCode(t *testing.T) {
+	ctx := logging.GetTestContext()
+	assert.Equal(t, userTypeCode(ctx, ""), "E")
+	assert.Equal(t, userTypeCode(ctx, "AD user"), "E")
+	assert.Equal(t, userTypeCode(ctx, "AD group"), "X")
+	assert.False(t, logging.HasError(ctx))
+
+	assert.Equal(t, userTypeCode(ctx, "SQL user"), "")
+	assert.True(t, logging.HasError(ctx))
+}


### PR DESCRIPTION
This pull request adds support for provisioning Azure SQL users as Entra ID (Azure AD) groups by introducing a configurable `type` attribute on the `azuresql_user` resource. Previously, only AD users could be provisioned via `entraid_identifier`, but now you can specify `type = "AD group"` to provision a group. The documentation and tests have been updated accordingly, and validation ensures correct usage of the new attribute.

**New Feature: Support for AD Groups**

* Added a `type` attribute to the `azuresql_user` resource, allowing users to specify `"AD group"` when provisioning with `entraid_identifier`. This enables mapping an Entra ID group to a SQL user. [[1]](diffhunk://#diff-36cebdc98738de9946e2f02e2e68b84fdf831e08df4f093dd6ff1e1840bf9ba7R10-R15) [[2]](diffhunk://#diff-9d5afa25b82640b5cc36dc5ff7d56a7dc665e0b3b985fa59be566b5716913cc6L82-L89) [[3]](diffhunk://#diff-249096df01154f201910b7dacb5d5c1d0b6f1e433f1fdc4e24393c7d5a1627e5R126-R136) [[4]](diffhunk://#diff-80570ebf8e201f66dd38c9b4674f45d3a351f7cfebcb05b93f295bbd464d6278R72-R86) [[5]](diffhunk://#diff-80570ebf8e201f66dd38c9b4674f45d3a351f7cfebcb05b93f295bbd464d6278L88-R103) [[6]](diffhunk://#diff-80570ebf8e201f66dd38c9b4674f45d3a351f7cfebcb05b93f295bbd464d6278R112-R116)

**Validation and Error Handling**

* Enforced that `type` can only be set if `entraid_identifier` is specified, with appropriate error messages and validation in both resource schema and config validation. [[1]](diffhunk://#diff-249096df01154f201910b7dacb5d5c1d0b6f1e433f1fdc4e24393c7d5a1627e5R198-R203) [[2]](diffhunk://#diff-249096df01154f201910b7dacb5d5c1d0b6f1e433f1fdc4e24393c7d5a1627e5L242-R264)

**Documentation Updates**

* Updated resource documentation and examples to demonstrate provisioning an AD group as a SQL user, and clarified the usage of the new `type` attribute. [[1]](diffhunk://#diff-9d5afa25b82640b5cc36dc5ff7d56a7dc665e0b3b985fa59be566b5716913cc6R58-R70) [[2]](diffhunk://#diff-9d5afa25b82640b5cc36dc5ff7d56a7dc665e0b3b985fa59be566b5716913cc6L82-L89)

**Testing**

* Added acceptance tests to verify group provisioning and to ensure errors are raised if `type` is set without `entraid_identifier`. Added unit tests for the user type code mapping. [[1]](diffhunk://#diff-36c35c9f0d3595a7044c36da273ae08c1b856445166bd20e0d5d2cde2b377b78R177-R212) [[2]](diffhunk://#diff-36c35c9f0d3595a7044c36da273ae08c1b856445166bd20e0d5d2cde2b377b78R347-R379) [[3]](diffhunk://#diff-1575c6fcafb72751275e455d9f62f5e4e59d9c7cfd7f42f8f74830f430639291R1-R19)

**Minor Improvements**

* Generalized the plan modifier description for attributes that force replacement.

**Linked Issue**
* https://github.com/jonascrevecoeur/terraform-provider-azuresql/issues/223